### PR TITLE
Add root AGENTS guidance for slash commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Guidance for AI Agents
+
+Welcome! This project uses user-defined slash commands to guide agentic workflows. **Before responding to any slash command**, you must consult the prompt definitions stored in [`.codex/prompts/`](.codex/prompts/).
+
+These markdown files document how each command should be interpreted. Reading them upfront ensures consistent behavior across turns.


### PR DESCRIPTION
## Summary
- add a root-level AGENTS.md directing agents to review the slash command prompts in .codex/prompts before responding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e176fe7ce88331babb6630ceac3f49